### PR TITLE
Adjust width of what-is-jellyfin section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1008,7 +1008,7 @@ font-size: 2rem;
       max-width: none; } }
 
 .step__text {
-  max-width: 36ch;
+  max-width: 25ch;
   text-align: center;
   margin-left: auto;
   margin-right: auto; }


### PR DESCRIPTION
The width allowed text to get too close together. Adjust it to a smaller max width so the text has plenty of space around the sides and the text doesn't collide.

![before](https://user-images.githubusercontent.com/4031396/65203906-913b3880-da5a-11e9-82fc-3899b5393b5c.png)
![after](https://user-images.githubusercontent.com/4031396/65203909-939d9280-da5a-11e9-9242-5f2a8ce15bc3.png)

Fixes #20 