### PR TITLE
Mention uninstalling ZIPs with installer

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -226,6 +226,7 @@ makepkg -si</code></pre>
                     <div class="windows">
                         <h4>Windows</h4>
                         <p>Both installers (.exe) and manual ZIP archives (.zip) are provided.</p>
+                        <p>When using the installer, please ensure you <i>fully uninstall</i> any ZIP archive versions you may have installed, or you may get duplicate services.
                         <p>
                         <a href="https://repo.jellyfin.org/releases/server/windows/stable" class="button button__accent">Stable</a>
                         <a href="https://repo.jellyfin.org/releases/server/windows/nightly" class="button button__accent">Nightly</a>


### PR DESCRIPTION
This helps avoid situations where two services are installed.

Addresses jellyfin/jellyfin-docs#85