### PR TITLE
Fix flipped Arch links

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -186,12 +186,12 @@ sudo apt install jellyfin-nightly</code></pre>
 					        } 
 						</script>
                         <div id="arch_aur_stable" style="display:none;">
-                            <pre><code>git clone https://aur.archlinux.org/jellyfin-git.git
+                            <pre><code>git clone https://aur.archlinux.org/jellyfin.git
 cd jellyfin
 makepkg -si</code></pre>
                         </div>
                         <div id="arch_aur_nightly" style="display:none;">
-                            <pre><code>git clone https://aur.archlinux.org/jellyfin.git
+                            <pre><code>git clone https://aur.archlinux.org/jellyfin-git.git
 cd jellyfin-git
 makepkg -si</code></pre>
                         </div>


### PR DESCRIPTION
Stable pointed to `-git`, so flip them.