### PR TITLE
Fix little inconsistency on the Contact tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
                     <li><a href="https://github.com/jellyfin">GitHub</a></li>
                     <li><a href="./docs/">Documentation</a></li>
                     <li><a href="./help-jellyfin">Help Jellyfin</a></li>
-                    <li><a href="./contact/">Contact</a></li>
+                    <li><a href="./contact/">Social/Contact Us</a></li>
                 </ul>
             </nav>
             <div class="navbar__menu-mob"><a href="" id='toggle'>


### PR DESCRIPTION
Right now on the main page the contact tab only says "Contact".

On other tabs it always says "Social/Contact Us"

Main page: https://i.imgur.com/ZztXSjl.png
Downloads: https://i.imgur.com/W5caaqf.png
Help Jellyfin: https://i.imgur.com/xLPXWu7.png