### PR TITLE
Specify Ubuntu Focal support

### DIFF
--- a/docs/general/administration/installing.html
+++ b/docs/general/administration/installing.html
@@ -503,7 +503,7 @@ sudo /etc/init.d/jellyfin stop
 </li>
 </ol>
 <h4 id="ubuntu-repository">Ubuntu Repository</h4>
-<p>The Jellyfin team provides an Ubuntu repository for installation on Ubuntu Xenial, Bionic, Cosmic, Disco, and Eoan. Supported architectures are <code>amd64</code>, <code>arm64</code>, and <code>armhf</code>. Only <code>amd64</code> is supported on Ubuntu Xenial.</p>
+<p>The Jellyfin team provides an Ubuntu repository for installation on Ubuntu Xenial, Bionic, Cosmic, Disco, Eoan, and Focal. Supported architectures are <code>amd64</code>, <code>arm64</code>, and <code>armhf</code>. Only <code>amd64</code> is supported on Ubuntu Xenial.</p>
 <div class="NOTE"><h5>Note</h5><p>Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is not supported on the <code>i386</code> architecture.</p>
 </div>
 <ol>
@@ -518,7 +518,7 @@ sudo /etc/init.d/jellyfin stop
 </code></pre></li>
 <li><p>Add a repository configuration at <code>/etc/apt/sources.list.d/jellyfin.list</code>:</p>
 <pre><code class="lang-sh">echo &quot;deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/ubuntu $( lsb_release -c -s ) main&quot; | sudo tee /etc/apt/sources.list.d/jellyfin.list
-</code></pre><div class="NOTE"><h5>Note</h5><p>Supported releases are <code>xenial</code>, <code>bionic</code>, <code>cosmic</code>, <code>disco</code>, and <code>eoan</code>.</p>
+</code></pre><div class="NOTE"><h5>Note</h5><p>Supported releases are <code>xenial</code>, <code>bionic</code>, <code>cosmic</code>, <code>disco</code>, <code>eoan</code>, and <code>focal</code>.</p>
 </div>
 </li>
 <li><p>Update APT repositories:</p>


### PR DESCRIPTION
Ubuntu 20.04 (codename "Focal") [is currently supported](https://github.com/jellyfin/jellyfin/pull/3615).